### PR TITLE
feat(azure): scope provisioner Graph permission to Application.ReadWrite.OwnedBy

### DIFF
--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -78,7 +78,7 @@ output "service_principal_client_id" {
 | azuread_service_principal.this | Service Principal for ClickHouse BYOC application |
 | azurerm_role_definition.clickhouse_byoc_provisioner | Custom role for ClickHouse to provision Azure BYOC infrastructure resources |
 | azurerm_role_assignment.this | Assigns 'ClickHouse BYOC Provisioner' role to the service principal |
-| azuread_app_role_assignment.graph_permissions["Application.ReadWrite.All"] | Grants Application.ReadWrite.All Microsoft Graph permission |
+| azuread_app_role_assignment.graph_permissions["Application.ReadWrite.OwnedBy"] | Grants Application.ReadWrite.OwnedBy Microsoft Graph permission |
 | azuread_app_role_assignment.graph_permissions["User.Invite.All"] | Grants User.Invite.All Microsoft Graph permission |
 | azuread_app_role_assignment.graph_permissions["User.ReadWrite.All"] | Grants User.ReadWrite.All Microsoft Graph permission |
 

--- a/modules/azure/locals.tf
+++ b/modules/azure/locals.tf
@@ -7,8 +7,9 @@ locals {
 
   # https://learn.microsoft.com/en-us/graph/permissions-reference
   graph_permissions = {
-    "Application.ReadWrite.All" = "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9"
-    "User.Invite.All"           = "09850681-111b-4a89-9bed-3f2cae46d706"
-    "User.ReadWrite.All"        = "741f803b-c850-494e-b5df-cde7c675a1ca"
+    # OwnedBy (not .All): provisioner only manages apps/SPs it creates and owns
+    "Application.ReadWrite.OwnedBy" = "18a4783c-866b-4cc7-a460-3d5e5662c884"
+    "User.Invite.All"               = "09850681-111b-4a89-9bed-3f2cae46d706"
+    "User.ReadWrite.All"            = "741f803b-c850-494e-b5df-cde7c675a1ca"
   }
 }


### PR DESCRIPTION
## Summary

Scope down the ClickHouse BYOC provisioner's Microsoft Graph permission in the customer tenant:

- `Application.ReadWrite.All` (`1bfefb4e-…`) → `Application.ReadWrite.OwnedBy` (`18a4783c-…`)

With `OwnedBy`, the provisioner can only manage the Entra applications and service principals it **creates and owns**, instead of every application in the customer tenant. The Crossplane composition already sets the provisioner service principal as an owner of the AKS Entra app/SP it provisions, so this tighter scope is sufficient.

## Credit

This is cherry-picked from **@bojan**'s (Bojan Djurkovic) original work on the `azure_readwrite_ownedby` branch (commit `81a981f`). This PR intentionally takes **only** the Graph permission change; the unrelated RBAC role-assignment `condition` (constrained delegation) work from that branch is left for a separate change.

## Test plan

- [ ] `terraform plan` shows the `azuread_app_role_assignment.graph_permissions` key changing from `Application.ReadWrite.All` to `Application.ReadWrite.OwnedBy` with no other diffs.
- [ ] Verify a new BYOC infra provisions cleanly in dev with the narrowed permission (provisioner owns the AKS app/SP it creates).

Made with [Cursor](https://cursor.com)