### PR TITLE
feat(azure): drop User.Invite.All + User.ReadWrite.All from onboarding (BYOC-480)

### DIFF
--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -79,8 +79,6 @@ output "service_principal_client_id" {
 | azurerm_role_definition.clickhouse_byoc_provisioner | Custom role for ClickHouse to provision Azure BYOC infrastructure resources |
 | azurerm_role_assignment.this | Assigns 'ClickHouse BYOC Provisioner' role to the service principal |
 | azuread_app_role_assignment.graph_permissions["Application.ReadWrite.OwnedBy"] | Grants Application.ReadWrite.OwnedBy Microsoft Graph permission |
-| azuread_app_role_assignment.graph_permissions["User.Invite.All"] | Grants User.Invite.All Microsoft Graph permission |
-| azuread_app_role_assignment.graph_permissions["User.ReadWrite.All"] | Grants User.ReadWrite.All Microsoft Graph permission |
 
 ## Requirements
 

--- a/modules/azure/locals.tf
+++ b/modules/azure/locals.tf
@@ -7,9 +7,13 @@ locals {
 
   # https://learn.microsoft.com/en-us/graph/permissions-reference
   graph_permissions = {
-    # OwnedBy (not .All): provisioner only manages apps/SPs it creates and owns
+    # OwnedBy (not .All): provisioner only manages apps/SPs it creates and owns.
+    # Used for the AKS workload-identity Application/ServicePrincipal — unrelated to
+    # engineer access.
     "Application.ReadWrite.OwnedBy" = "18a4783c-866b-4cc7-a460-3d5e5662c884"
-    "User.Invite.All"               = "09850681-111b-4a89-9bed-3f2cae46d706"
-    "User.ReadWrite.All"            = "741f803b-c850-494e-b5df-cde7c675a1ca"
+    # User.Invite.All / User.ReadWrite.All removed (BYOC-480): engineer access is now
+    # granted via per-engineer in-cluster Kubernetes ServiceAccounts + short-lived
+    # bound tokens, not Entra B2B guest invitations — so no directory/Graph user
+    # permission is required for engineer access.
   }
 }


### PR DESCRIPTION
## What

Removes **`User.Invite.All`** and **`User.ReadWrite.All`** from the Azure BYOC onboarding app's Microsoft Graph permissions (`modules/azure`). Only **`Application.ReadWrite.OwnedBy`** remains (AKS workload-identity app/SP — unrelated to engineer access).

## Why

BYOC-480 changed engineer access to a customer's AKS: per-engineer **in-cluster Kubernetes ServiceAccount + short-lived bound token** (minted by data-plane-management), instead of Entra **B2B guest invitations**. That path is pure in-cluster Kubernetes RBAC — no directory/Graph user permission — so the provisioner app no longer needs `User.Invite.All` or `User.ReadWrite.All`.

Verified in data-plane-application: the only Graph-backed resources the provisioner creates are the AKS Application/ServicePrincipal (`Application.ReadWrite.OwnedBy`) and — in **legacy** mode only — the engineer `Invitation`; SA-access mode renders neither, and no mgmt code reads/writes directory users.

## Effect on apply

The two `azuread_app_role_assignment.graph_permissions` entries are destroyed (`for_each` over the map), **revoking the consented grants in the customer tenant**.

## Dependency

Assumes Azure BYOC infras run in **ServiceAccount-access mode** (`engineerServiceAccountAccess=true`); the legacy guest-invitation engineer path (which needs `User.Invite.All`) is not used under this onboarding. SA-access is merged + e2e-verified on dev (Azure + GCP) under BYOC-480.

## Validation

`terraform fmt -check` + `terraform validate` pass.

BYOC-480