### PR TITLE
feat(gcp): support Shared VPC host project in BYOC onboarding

### DIFF
--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -15,12 +15,34 @@ module "clickhouse_onboarding" {
 }
 ```
 
+### Shared VPC (bring a VPC from a different project)
+
+If the VPC you bring lives in a **different** GCP project (the Shared VPC *host* project) than the BYOC *service* project where ClickHouse runs GKE, set `network_project_id` (plus the host subnet's `region` and `private_subnet_id`). The module then grants the network and GKE Shared VPC permissions in the host project, in addition to the standard service-project setup.
+
+```hcl
+module "clickhouse_onboarding" {
+  source             = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.0.0"
+  project_id         = "replace-with-your-clickhouse-byoc-service-project-id"
+  network_project_id = "replace-with-your-shared-vpc-host-project-id"
+  region             = "us-central1"
+  private_subnet_id  = "replace-with-your-host-subnet-name"
+}
+```
+
+**Prerequisites for Shared VPC:**
+
+- The host project must already be enabled as a [Shared VPC host](https://cloud.google.com/vpc/docs/provisioning-shared-vpc) and the service project (`project_id`) attached to it. This is an org-level operation (`compute.xpnAdmin`) and is **not** performed by this module.
+- The credentials running this module must have IAM admin on **both** the service project (`project_id`) and the host project (`network_project_id`).
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | project_id | (Required) The GCP project ID where resources will be provisioned | string | n/a | yes |
 | environment | (Optional) Environment. Default is `production`. The other values are reserved for internal use | string | `production` | no |
+| network_project_id | (Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `region` and `private_subnet_id` are required | string | `""` | no |
+| region | (Optional) The region of the Shared VPC host subnet. Required only when `network_project_id` is set | string | `""` | no |
+| private_subnet_id | (Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `network_project_id` is set | string | `""` | no |
 
 ## Outputs
 
@@ -28,6 +50,9 @@ module "clickhouse_onboarding" {
 |------|-------------|
 | clickhouse_management_sa_name | The name of the ClickHouse Management Service Account | string |
 | clickhouse_management_sa_roles | List of role IDs assigned to the ClickHouse Management Service Account | list(string) |
+| shared_vpc_enabled | Whether Shared VPC host-project resources were provisioned (true when `network_project_id` is set) | bool |
+| shared_vpc_host_role | The ID of the ClickHouse Shared VPC host role granted in the host project, or null when Shared VPC is not used | string |
+| gke_service_agent_member | The service project's GKE service agent granted access to the Shared VPC host project, or null when Shared VPC is not used | string |
 
 ## Resources
 
@@ -46,6 +71,11 @@ module "clickhouse_onboarding" {
 | google_project_iam_member.clickhouse_sa_roles["storage_role"] | Grants `clickhouseStorageRole` to ClickHouse Management Service Account |
 | google_project_iam_member.clickhouse_sa_roles["iam_role"] | Grants `clickhouseIamRole` to ClickHouse Management Service Account |
 | google_service_account_iam_binding.impersonation_binding | Allows ClickHouse Crossplane Service Account to impersonate ClickHouse Management Service Account |
+| google_project_iam_custom_role.clickhouse_shared_vpc_host_role | [Shared VPC] Role to use the host network and manage PrivateLink resources in the host project |
+| google_project_iam_member.clickhouse_sa_shared_vpc_host_role | [Shared VPC] Grants `clickhouseSharedVPCHostRole` to ClickHouse Management Service Account in the host project |
+| google_project_service.container | [Shared VPC] Enables the Container API on the service project so its GKE service agent exists |
+| google_project_iam_member.gke_host_service_agent_user | [Shared VPC] Grants `roles/container.hostServiceAgentUser` to the service project's GKE service agent on the host project |
+| google_compute_subnetwork_iam_member.network_user | [Shared VPC] Grants `roles/compute.networkUser` on the host subnet to the GKE service agent, Google APIs SA, and ClickHouse Management Service Account |
 
 ## Requirements
 

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -10,7 +10,7 @@ provider "google" {
 }
 
 module "clickhouse_onboarding" {
-  source     = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.0.0"
+  source     = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.2.0"
   project_id = "replace-with-your-clickhouse-byoc-project-id"
 }
 ```
@@ -21,7 +21,7 @@ If the VPC you bring lives in a **different** GCP project (the Shared VPC *host*
 
 ```hcl
 module "clickhouse_onboarding" {
-  source                            = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.0.0"
+  source                            = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.2.0"
   project_id                        = "replace-with-your-clickhouse-byoc-service-project-id"
   shared_vpc_host_project_id        = "replace-with-your-shared-vpc-host-project-id"
   shared_vpc_host_subnet_region     = "us-central1"

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -21,13 +21,16 @@ If the VPC you bring lives in a **different** GCP project (the Shared VPC *host*
 
 ```hcl
 module "clickhouse_onboarding" {
-  source             = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.0.0"
-  project_id         = "replace-with-your-clickhouse-byoc-service-project-id"
-  network_project_id = "replace-with-your-shared-vpc-host-project-id"
-  region             = "us-central1"
-  private_subnet_id  = "replace-with-your-host-subnet-name"
+  source              = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.0.0"
+  project_id          = "replace-with-your-clickhouse-byoc-service-project-id"
+  network_project_id  = "replace-with-your-shared-vpc-host-project-id"
+  region              = "us-central1"
+  private_subnet_id   = "replace-with-your-host-subnet-name"
+  enable_private_link = true # only if you will use ClickHouse Private Service Connect (PrivateLink)
 }
 ```
+
+By default the host project grants are read-only (observe the brought network/subnet); GKE consumes the host subnet via a `compute.networkUser` binding. Set `enable_private_link = true` to additionally grant the host-project permissions needed to manage the PrivateLink PSC NAT subnet (subnets in a Shared VPC belong to the host project). Leave it `false` to keep the host-project permission surface minimal.
 
 **Prerequisites for Shared VPC:**
 
@@ -43,6 +46,7 @@ module "clickhouse_onboarding" {
 | network_project_id | (Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `region` and `private_subnet_id` are required | string | `""` | no |
 | region | (Optional) The region of the Shared VPC host subnet. Required only when `network_project_id` is set | string | `""` | no |
 | private_subnet_id | (Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `network_project_id` is set | string | `""` | no |
+| enable_private_link | (Optional) Set to true if you will use ClickHouse Private Service Connect (PrivateLink) with this Shared VPC. Grants the additional host-project permissions to manage the PSC NAT subnet. Only takes effect when `network_project_id` is set | bool | `false` | no |
 
 ## Outputs
 
@@ -71,7 +75,7 @@ module "clickhouse_onboarding" {
 | google_project_iam_member.clickhouse_sa_roles["storage_role"] | Grants `clickhouseStorageRole` to ClickHouse Management Service Account |
 | google_project_iam_member.clickhouse_sa_roles["iam_role"] | Grants `clickhouseIamRole` to ClickHouse Management Service Account |
 | google_service_account_iam_binding.impersonation_binding | Allows ClickHouse Crossplane Service Account to impersonate ClickHouse Management Service Account |
-| google_project_iam_custom_role.clickhouse_shared_vpc_host_role | [Shared VPC] Role to use the host network and manage PrivateLink resources in the host project |
+| google_project_iam_custom_role.clickhouse_shared_vpc_host_role | [Shared VPC] Role to observe the host network/subnet, plus manage the PrivateLink PSC NAT subnet when `enable_private_link` is true |
 | google_project_iam_member.clickhouse_sa_shared_vpc_host_role | [Shared VPC] Grants `clickhouseSharedVPCHostRole` to ClickHouse Management Service Account in the host project |
 | google_project_service.container | [Shared VPC] Enables the Container API on the service project so its GKE service agent exists |
 | google_project_iam_member.gke_host_service_agent_user | [Shared VPC] Grants `roles/container.hostServiceAgentUser` to the service project's GKE service agent on the host project |

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -17,25 +17,25 @@ module "clickhouse_onboarding" {
 
 ### Shared VPC (bring a VPC from a different project)
 
-If the VPC you bring lives in a **different** GCP project (the Shared VPC *host* project) than the BYOC *service* project where ClickHouse runs GKE, set `network_project_id` (plus the host subnet's `region` and `private_subnet_id`). The module then grants the network and GKE Shared VPC permissions in the host project, in addition to the standard service-project setup.
+If the VPC you bring lives in a **different** GCP project (the Shared VPC *host* project) than the BYOC *service* project where ClickHouse runs GKE, set `shared_vpc_host_project_id` (plus the host subnet's `shared_vpc_host_subnet_region` and `shared_vpc_host_private_subnet_id`). The module then grants the network and GKE Shared VPC permissions in the host project, in addition to the standard service-project setup.
 
 ```hcl
 module "clickhouse_onboarding" {
-  source              = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.0.0"
-  project_id          = "replace-with-your-clickhouse-byoc-service-project-id"
-  network_project_id  = "replace-with-your-shared-vpc-host-project-id"
-  region              = "us-central1"
-  private_subnet_id   = "replace-with-your-host-subnet-name"
-  enable_private_link = true # only if you will use ClickHouse Private Service Connect (PrivateLink)
+  source                            = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.0.0"
+  project_id                        = "replace-with-your-clickhouse-byoc-service-project-id"
+  shared_vpc_host_project_id        = "replace-with-your-shared-vpc-host-project-id"
+  shared_vpc_host_subnet_region     = "us-central1"
+  shared_vpc_host_private_subnet_id = "replace-with-your-host-subnet-name"
+  enable_shared_vpc_private_link    = true # only if you will use ClickHouse Private Service Connect (PrivateLink)
 }
 ```
 
-By default the host project grants are read-only (observe the brought network/subnet); GKE consumes the host subnet via a `compute.networkUser` binding. Set `enable_private_link = true` to additionally grant the host-project permissions needed to manage the PrivateLink PSC NAT subnet (subnets in a Shared VPC belong to the host project). Leave it `false` to keep the host-project permission surface minimal.
+By default the host project grants are read-only (observe the brought network/subnet); GKE consumes the host subnet via a `compute.networkUser` binding. Set `enable_shared_vpc_private_link = true` to additionally grant the host-project permissions needed to manage the PrivateLink PSC NAT subnet (subnets in a Shared VPC belong to the host project). Leave it `false` to keep the host-project permission surface minimal.
 
 **Prerequisites for Shared VPC:**
 
 - The host project must already be enabled as a [Shared VPC host](https://cloud.google.com/vpc/docs/provisioning-shared-vpc) and the service project (`project_id`) attached to it. This is an org-level operation (`compute.xpnAdmin`) and is **not** performed by this module.
-- The credentials running this module must have IAM admin on **both** the service project (`project_id`) and the host project (`network_project_id`).
+- The credentials running this module must have IAM admin on **both** the service project (`project_id`) and the host project (`shared_vpc_host_project_id`).
 
 ## Inputs
 
@@ -43,10 +43,10 @@ By default the host project grants are read-only (observe the brought network/su
 |------|-------------|------|---------|:--------:|
 | project_id | (Required) The GCP project ID where resources will be provisioned | string | n/a | yes |
 | environment | (Optional) Environment. Default is `production`. The other values are reserved for internal use | string | `production` | no |
-| network_project_id | (Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `region` and `private_subnet_id` are required | string | `""` | no |
-| region | (Optional) The region of the Shared VPC host subnet. Required only when `network_project_id` is set | string | `""` | no |
-| private_subnet_id | (Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `network_project_id` is set | string | `""` | no |
-| enable_private_link | (Optional) Set to true if you will use ClickHouse Private Service Connect (PrivateLink) with this Shared VPC. Grants the additional host-project permissions to manage the PSC NAT subnet. Only takes effect when `network_project_id` is set | bool | `false` | no |
+| shared_vpc_host_project_id | (Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `shared_vpc_host_subnet_region` and `shared_vpc_host_private_subnet_id` are required | string | `""` | no |
+| shared_vpc_host_subnet_region | (Optional) The region of the Shared VPC host subnet. Required only when `shared_vpc_host_project_id` is set | string | `""` | no |
+| shared_vpc_host_private_subnet_id | (Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `shared_vpc_host_project_id` is set | string | `""` | no |
+| enable_shared_vpc_private_link | (Optional) Set to true if you will use ClickHouse Private Service Connect (PrivateLink) with this Shared VPC. Grants the additional host-project permissions to manage the PSC NAT subnet. Only takes effect when `shared_vpc_host_project_id` is set | bool | `false` | no |
 
 ## Outputs
 
@@ -54,7 +54,7 @@ By default the host project grants are read-only (observe the brought network/su
 |------|-------------|
 | clickhouse_management_sa_name | The name of the ClickHouse Management Service Account | string |
 | clickhouse_management_sa_roles | List of role IDs assigned to the ClickHouse Management Service Account | list(string) |
-| shared_vpc_enabled | Whether Shared VPC host-project resources were provisioned (true when `network_project_id` is set) | bool |
+| shared_vpc_enabled | Whether Shared VPC host-project resources were provisioned (true when `shared_vpc_host_project_id` is set) | bool |
 | shared_vpc_host_role | The ID of the ClickHouse Shared VPC host role granted in the host project, or null when Shared VPC is not used | string |
 | gke_service_agent_member | The service project's GKE service agent granted access to the Shared VPC host project, or null when Shared VPC is not used | string |
 
@@ -75,7 +75,7 @@ By default the host project grants are read-only (observe the brought network/su
 | google_project_iam_member.clickhouse_sa_roles["storage_role"] | Grants `clickhouseStorageRole` to ClickHouse Management Service Account |
 | google_project_iam_member.clickhouse_sa_roles["iam_role"] | Grants `clickhouseIamRole` to ClickHouse Management Service Account |
 | google_service_account_iam_binding.impersonation_binding | Allows ClickHouse Crossplane Service Account to impersonate ClickHouse Management Service Account |
-| google_project_iam_custom_role.clickhouse_shared_vpc_host_role | [Shared VPC] Role to observe the host network/subnet, plus manage the PrivateLink PSC NAT subnet when `enable_private_link` is true |
+| google_project_iam_custom_role.clickhouse_shared_vpc_host_role | [Shared VPC] Role to observe the host network/subnet, plus manage the PrivateLink PSC NAT subnet when `enable_shared_vpc_private_link` is true |
 | google_project_iam_member.clickhouse_sa_shared_vpc_host_role | [Shared VPC] Grants `clickhouseSharedVPCHostRole` to ClickHouse Management Service Account in the host project |
 | google_project_service.container | [Shared VPC] Enables the Container API on the service project so its GKE service agent exists |
 | google_project_iam_member.gke_host_service_agent_user | [Shared VPC] Grants `roles/container.hostServiceAgentUser` to the service project's GKE service agent on the host project |

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -9,3 +9,18 @@ output "clickhouse_management_sa_roles" {
   ]
   description = "List of role IDs assigned to the ClickHouse Management Service Account"
 }
+
+output "shared_vpc_enabled" {
+  value       = local.shared_vpc
+  description = "Whether Shared VPC host-project resources were provisioned (true when network_project_id is set)"
+}
+
+output "shared_vpc_host_role" {
+  value       = one(google_project_iam_custom_role.clickhouse_shared_vpc_host_role[*].id)
+  description = "The ID of the ClickHouse Shared VPC host role granted in the host project, or null when Shared VPC is not used"
+}
+
+output "gke_service_agent_member" {
+  value       = local.shared_vpc ? local.gke_service_agent_member : null
+  description = "The service project's GKE service agent granted access to the Shared VPC host project, or null when Shared VPC is not used"
+}

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -12,7 +12,7 @@ output "clickhouse_management_sa_roles" {
 
 output "shared_vpc_enabled" {
   value       = local.shared_vpc
-  description = "Whether Shared VPC host-project resources were provisioned (true when network_project_id is set)"
+  description = "Whether Shared VPC host-project resources were provisioned (true when shared_vpc_host_project_id is set)"
 }
 
 output "shared_vpc_host_role" {

--- a/modules/gcp/shared_vpc.tf
+++ b/modules/gcp/shared_vpc.tf
@@ -9,6 +9,11 @@
 locals {
   shared_vpc = var.network_project_id != ""
 
+  # PSC host-project permissions apply only when both Shared VPC is in use and
+  # the customer intends to use PrivateLink. When PrivateLink is off we keep the
+  # host-project permission surface to the read-only observe set below.
+  enable_psc_host = local.shared_vpc && var.enable_private_link
+
   # GKE service agents of the service project (this project). These are
   # well-known, derived from the project number, and must be granted access to
   # the host network for a Shared VPC GKE cluster. Referenced only by the
@@ -16,6 +21,35 @@ locals {
   service_project_number   = one(data.google_project.service[*].number)
   gke_service_agent_member = local.shared_vpc ? "serviceAccount:service-${local.service_project_number}@container-engine-robot.iam.gserviceaccount.com" : null
   cloudservices_sa_member  = local.shared_vpc ? "serviceAccount:${local.service_project_number}@cloudservices.gserviceaccount.com" : null
+
+  # Always needed in the host project under Shared VPC: observe the brought
+  # network/subnet (Crossplane manages them Observe-only, and the onboarding
+  # validator reads them here). Using the node subnet is granted separately via
+  # the compute.networkUser binding below.
+  shared_vpc_host_base_permissions = [
+    "compute.networks.get",
+    "compute.subnetworks.get",
+  ]
+
+  # PrivateLink only: manage the PSC NAT subnet, which — like every subnet in a
+  # Shared VPC — is created in the host project. subnetworks.use lets the
+  # service-project ServiceAttachment reference this host subnet as its NAT
+  # subnet; regionOperations.get polls the async subnet create/delete. The
+  # ServiceAttachment itself lives in the service project and is covered by the
+  # service-project clickhouseVPCRole, so no serviceAttachments/forwardingRules
+  # permissions are needed here.
+  shared_vpc_host_psc_permissions = [
+    "compute.subnetworks.create",
+    "compute.subnetworks.delete",
+    "compute.subnetworks.update",
+    "compute.subnetworks.use",
+    "compute.regionOperations.get",
+  ]
+
+  shared_vpc_host_permissions = concat(
+    local.shared_vpc_host_base_permissions,
+    local.enable_psc_host ? local.shared_vpc_host_psc_permissions : [],
+  )
 }
 
 data "google_project" "service" {
@@ -24,9 +58,10 @@ data "google_project" "service" {
   project_id = var.project_id
 }
 
-# Network/PSC permissions ClickHouse needs in the host project: observe the
-# brought network/subnet and create the PrivateLink PSC subnet + service
-# attachment in the host VPC.
+# Permissions ClickHouse needs in the Shared VPC host project: observe the
+# brought network/subnet, plus (when PrivateLink is enabled) manage the PSC NAT
+# subnet. The exact permission set is assembled in locals from the base +
+# optional PSC groups.
 resource "google_project_iam_custom_role" "clickhouse_shared_vpc_host_role" {
   count = local.shared_vpc ? 1 : 0
 
@@ -40,28 +75,8 @@ resource "google_project_iam_custom_role" "clickhouse_shared_vpc_host_role" {
   project     = var.network_project_id
   role_id     = "clickhouseSharedVPCHostRole"
   title       = "ClickHouse Shared VPC Host Role"
-  description = "Role to allow ClickHouse Cloud to use the Shared VPC host network and manage PrivateLink resources in the host project"
-  permissions = [
-    # Network
-    "compute.networks.get",
-    "compute.networks.use",
-
-    # Subnetwork (observe brought subnet, manage PSC NAT subnet)
-    "compute.subnetworks.create",
-    "compute.subnetworks.delete",
-    "compute.subnetworks.get",
-    "compute.subnetworks.list",
-    "compute.subnetworks.use",
-
-    # Private Service Connect
-    "compute.serviceAttachments.create",
-    "compute.serviceAttachments.delete",
-    "compute.serviceAttachments.get",
-    "compute.serviceAttachments.list",
-    "compute.serviceAttachments.update",
-    "compute.forwardingRules.use",
-    "compute.regionOperations.get",
-  ]
+  description = "Role to allow ClickHouse Cloud to observe the Shared VPC host network/subnet (and manage the PrivateLink PSC NAT subnet when enabled)"
+  permissions = local.shared_vpc_host_permissions
 }
 
 resource "google_project_iam_member" "clickhouse_sa_shared_vpc_host_role" {

--- a/modules/gcp/shared_vpc.tf
+++ b/modules/gcp/shared_vpc.tf
@@ -65,13 +65,6 @@ data "google_project" "service" {
 resource "google_project_iam_custom_role" "clickhouse_shared_vpc_host_role" {
   count = local.shared_vpc ? 1 : 0
 
-  lifecycle {
-    precondition {
-      condition     = var.region != "" && var.private_subnet_id != ""
-      error_message = "region and private_subnet_id are required when network_project_id is set."
-    }
-  }
-
   project     = var.network_project_id
   role_id     = "clickhouseSharedVPCHostRole"
   title       = "ClickHouse Shared VPC Host Role"
@@ -116,6 +109,16 @@ resource "google_compute_subnetwork_iam_member" "network_user" {
     cloudservices     = local.cloudservices_sa_member
     management_sa     = google_service_account.clickhouse_management_sa.member
   } : {}
+
+  # region and private_subnet_id are consumed here, so this is where we assert
+  # they were supplied alongside network_project_id (Terraform < 1.9 can't do
+  # cross-variable validation in the variable block itself).
+  lifecycle {
+    precondition {
+      condition     = var.region != "" && var.private_subnet_id != ""
+      error_message = "region and private_subnet_id are required when network_project_id is set."
+    }
+  }
 
   depends_on = [google_project_service.container]
   project    = var.network_project_id

--- a/modules/gcp/shared_vpc.tf
+++ b/modules/gcp/shared_vpc.tf
@@ -1,0 +1,111 @@
+# Shared VPC support: granted only when the VPC you bring lives in a separate
+# host project (network_project_id set). All resources here target that host
+# project via their explicit project/region/subnetwork arguments, so the
+# single google provider's credentials must have IAM admin on both projects.
+#
+# Prerequisite (customer, org-level): the host project must already be enabled
+# as a Shared VPC host and this project attached as a service project.
+
+locals {
+  shared_vpc = var.network_project_id != ""
+
+  # GKE service agents of the service project (this project). These are
+  # well-known, derived from the project number, and must be granted access to
+  # the host network for a Shared VPC GKE cluster. Referenced only by the
+  # Shared-VPC-gated resources below, so the splat is safe when disabled.
+  service_project_number   = one(data.google_project.service[*].number)
+  gke_service_agent_member = local.shared_vpc ? "serviceAccount:service-${local.service_project_number}@container-engine-robot.iam.gserviceaccount.com" : null
+  cloudservices_sa_member  = local.shared_vpc ? "serviceAccount:${local.service_project_number}@cloudservices.gserviceaccount.com" : null
+}
+
+data "google_project" "service" {
+  count = local.shared_vpc ? 1 : 0
+
+  project_id = var.project_id
+}
+
+# Network/PSC permissions ClickHouse needs in the host project: observe the
+# brought network/subnet and create the PrivateLink PSC subnet + service
+# attachment in the host VPC.
+resource "google_project_iam_custom_role" "clickhouse_shared_vpc_host_role" {
+  count = local.shared_vpc ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = var.region != "" && var.private_subnet_id != ""
+      error_message = "region and private_subnet_id are required when network_project_id is set."
+    }
+  }
+
+  project     = var.network_project_id
+  role_id     = "clickhouseSharedVPCHostRole"
+  title       = "ClickHouse Shared VPC Host Role"
+  description = "Role to allow ClickHouse Cloud to use the Shared VPC host network and manage PrivateLink resources in the host project"
+  permissions = [
+    # Network
+    "compute.networks.get",
+    "compute.networks.use",
+
+    # Subnetwork (observe brought subnet, manage PSC NAT subnet)
+    "compute.subnetworks.create",
+    "compute.subnetworks.delete",
+    "compute.subnetworks.get",
+    "compute.subnetworks.list",
+    "compute.subnetworks.use",
+
+    # Private Service Connect
+    "compute.serviceAttachments.create",
+    "compute.serviceAttachments.delete",
+    "compute.serviceAttachments.get",
+    "compute.serviceAttachments.list",
+    "compute.serviceAttachments.update",
+    "compute.forwardingRules.use",
+    "compute.regionOperations.get",
+  ]
+}
+
+resource "google_project_iam_member" "clickhouse_sa_shared_vpc_host_role" {
+  count = local.shared_vpc ? 1 : 0
+
+  project = var.network_project_id
+  role    = google_project_iam_custom_role.clickhouse_shared_vpc_host_role[0].id
+  member  = google_service_account.clickhouse_management_sa.member
+}
+
+# Enable the Container API on the service project so its GKE service agent is
+# created before we grant it access to the host network.
+resource "google_project_service" "container" {
+  count = local.shared_vpc ? 1 : 0
+
+  service            = "container.googleapis.com"
+  disable_on_destroy = false
+}
+
+# GKE Shared VPC: the service project's GKE service agent must be able to act on
+# the host project.
+resource "google_project_iam_member" "gke_host_service_agent_user" {
+  count = local.shared_vpc ? 1 : 0
+
+  depends_on = [google_project_service.container]
+  project    = var.network_project_id
+  role       = "roles/container.hostServiceAgentUser"
+  member     = local.gke_service_agent_member
+}
+
+# compute.networkUser on the host subnet for the principals that consume it:
+# the GKE service agent, the Google APIs (cloudservices) SA, and the ClickHouse
+# management SA that creates the cluster and PSC resources.
+resource "google_compute_subnetwork_iam_member" "network_user" {
+  for_each = local.shared_vpc ? {
+    gke_service_agent = local.gke_service_agent_member
+    cloudservices     = local.cloudservices_sa_member
+    management_sa     = google_service_account.clickhouse_management_sa.member
+  } : {}
+
+  depends_on = [google_project_service.container]
+  project    = var.network_project_id
+  region     = var.region
+  subnetwork = var.private_subnet_id
+  role       = "roles/compute.networkUser"
+  member     = each.value
+}

--- a/modules/gcp/shared_vpc.tf
+++ b/modules/gcp/shared_vpc.tf
@@ -1,5 +1,5 @@
 # Shared VPC support: granted only when the VPC you bring lives in a separate
-# host project (network_project_id set). All resources here target that host
+# host project (shared_vpc_host_project_id set). All resources here target that host
 # project via their explicit project/region/subnetwork arguments, so the
 # single google provider's credentials must have IAM admin on both projects.
 #
@@ -7,12 +7,12 @@
 # as a Shared VPC host and this project attached as a service project.
 
 locals {
-  shared_vpc = var.network_project_id != ""
+  shared_vpc = var.shared_vpc_host_project_id != ""
 
   # PSC host-project permissions apply only when both Shared VPC is in use and
   # the customer intends to use PrivateLink. When PrivateLink is off we keep the
   # host-project permission surface to the read-only observe set below.
-  enable_psc_host = local.shared_vpc && var.enable_private_link
+  enable_psc_host = local.shared_vpc && var.enable_shared_vpc_private_link
 
   # GKE service agents of the service project (this project). These are
   # well-known, derived from the project number, and must be granted access to
@@ -65,7 +65,7 @@ data "google_project" "service" {
 resource "google_project_iam_custom_role" "clickhouse_shared_vpc_host_role" {
   count = local.shared_vpc ? 1 : 0
 
-  project     = var.network_project_id
+  project     = var.shared_vpc_host_project_id
   role_id     = "clickhouseSharedVPCHostRole"
   title       = "ClickHouse Shared VPC Host Role"
   description = "Role to allow ClickHouse Cloud to observe the Shared VPC host network/subnet (and manage the PrivateLink PSC NAT subnet when enabled)"
@@ -75,7 +75,7 @@ resource "google_project_iam_custom_role" "clickhouse_shared_vpc_host_role" {
 resource "google_project_iam_member" "clickhouse_sa_shared_vpc_host_role" {
   count = local.shared_vpc ? 1 : 0
 
-  project = var.network_project_id
+  project = var.shared_vpc_host_project_id
   role    = google_project_iam_custom_role.clickhouse_shared_vpc_host_role[0].id
   member  = google_service_account.clickhouse_management_sa.member
 }
@@ -95,7 +95,7 @@ resource "google_project_iam_member" "gke_host_service_agent_user" {
   count = local.shared_vpc ? 1 : 0
 
   depends_on = [google_project_service.container]
-  project    = var.network_project_id
+  project    = var.shared_vpc_host_project_id
   role       = "roles/container.hostServiceAgentUser"
   member     = local.gke_service_agent_member
 }
@@ -110,20 +110,20 @@ resource "google_compute_subnetwork_iam_member" "network_user" {
     management_sa     = google_service_account.clickhouse_management_sa.member
   } : {}
 
-  # region and private_subnet_id are consumed here, so this is where we assert
-  # they were supplied alongside network_project_id (Terraform < 1.9 can't do
+  # The region/subnet are consumed here, so this is where we assert they were
+  # supplied alongside shared_vpc_host_project_id (Terraform < 1.9 can't do
   # cross-variable validation in the variable block itself).
   lifecycle {
     precondition {
-      condition     = var.region != "" && var.private_subnet_id != ""
-      error_message = "region and private_subnet_id are required when network_project_id is set."
+      condition     = var.shared_vpc_host_subnet_region != "" && var.shared_vpc_host_private_subnet_id != ""
+      error_message = "shared_vpc_host_subnet_region and shared_vpc_host_private_subnet_id are required when shared_vpc_host_project_id is set."
     }
   }
 
   depends_on = [google_project_service.container]
-  project    = var.network_project_id
-  region     = var.region
-  subnetwork = var.private_subnet_id
+  project    = var.shared_vpc_host_project_id
+  region     = var.shared_vpc_host_subnet_region
+  subnetwork = var.shared_vpc_host_private_subnet_id
   role       = "roles/compute.networkUser"
   member     = each.value
 }

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -31,3 +31,9 @@ variable "private_subnet_id" {
   description = "(Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `network_project_id` is set."
   default     = ""
 }
+
+variable "enable_private_link" {
+  type        = bool
+  description = "(Optional) Set to true if you will use ClickHouse Private Service Connect (PrivateLink) with this Shared VPC. Grants the additional host-project permissions needed to create and manage the PSC NAT subnet (subnets in a Shared VPC belong to the host project). Only takes effect when `network_project_id` is set; leave false to keep the host-project permission surface minimal."
+  default     = false
+}

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -13,3 +13,21 @@ variable "environment" {
     error_message = "Environment must be one of: production, staging, development"
   }
 }
+
+variable "network_project_id" {
+  type        = string
+  description = "(Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `region` and `private_subnet_id` are required."
+  default     = ""
+}
+
+variable "region" {
+  type        = string
+  description = "(Optional) The region of the Shared VPC host subnet. Required only when `network_project_id` is set."
+  default     = ""
+}
+
+variable "private_subnet_id" {
+  type        = string
+  description = "(Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `network_project_id` is set."
+  default     = ""
+}

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -14,26 +14,26 @@ variable "environment" {
   }
 }
 
-variable "network_project_id" {
+variable "shared_vpc_host_project_id" {
   type        = string
-  description = "(Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `region` and `private_subnet_id` are required."
+  description = "(Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `shared_vpc_host_subnet_region` and `shared_vpc_host_private_subnet_id` are required."
   default     = ""
 }
 
-variable "region" {
+variable "shared_vpc_host_subnet_region" {
   type        = string
-  description = "(Optional) The region of the Shared VPC host subnet. Required only when `network_project_id` is set."
+  description = "(Optional) The region of the Shared VPC host subnet. Required only when `shared_vpc_host_project_id` is set."
   default     = ""
 }
 
-variable "private_subnet_id" {
+variable "shared_vpc_host_private_subnet_id" {
   type        = string
-  description = "(Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `network_project_id` is set."
+  description = "(Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `shared_vpc_host_project_id` is set."
   default     = ""
 }
 
-variable "enable_private_link" {
+variable "enable_shared_vpc_private_link" {
   type        = bool
-  description = "(Optional) Set to true if you will use ClickHouse Private Service Connect (PrivateLink) with this Shared VPC. Grants the additional host-project permissions needed to create and manage the PSC NAT subnet (subnets in a Shared VPC belong to the host project). Only takes effect when `network_project_id` is set; leave false to keep the host-project permission surface minimal."
+  description = "(Optional) Set to true if you will use ClickHouse Private Service Connect (PrivateLink) with this Shared VPC. Grants the additional host-project permissions needed to create and manage the PSC NAT subnet (subnets in a Shared VPC belong to the host project). Only takes effect when `shared_vpc_host_project_id` is set; leave false to keep the host-project permission surface minimal."
   default     = false
 }


### PR DESCRIPTION
# Why

For GCP BYOC, a customer may want the VPC they bring to live in a **different** GCP project than the project where ClickHouse runs GKE — i.e. GCP Shared VPC (a *host* project owning the network, a *service* project running the cluster). Today this module is single-project: it grants all network/cluster IAM at the service-project scope, so a host-project VPC cannot be used.

# What

Adds optional Shared VPC support to `modules/gcp`, gated entirely on a new `network_project_id` input. When it is empty (the default), behavior is unchanged for existing same-project callers. When set, the module additionally provisions, in the **host** project:

- `clickhouseSharedVPCHostRole` custom role + grant to the `clickhouse-management` SA — network get/use, subnetwork CRUD+use (for the PrivateLink PSC NAT subnet), and service-attachment management.
- `roles/container.hostServiceAgentUser` to the service project's GKE service agent.
- `roles/compute.networkUser` on the host subnet for the GKE service agent, the Google APIs (`cloudservices`) SA, and the management SA.
- Enables `container.googleapis.com` on the service project so its GKE service agent exists.

Scope is **BYO-VPC only** (observe the brought network/subnet; create only the PrivateLink PSC resources in the host project). Managed-VPC-in-a-separate-project (Cloud Router/NAT/routes) is out of scope.

## New inputs / outputs (public API)

- Inputs: `network_project_id` (opt-in), plus `region` and `private_subnet_id` (required only when `network_project_id` is set; enforced via a `lifecycle.precondition`).
- Outputs: `shared_vpc_enabled`, `shared_vpc_host_role`, `gke_service_agent_member`.

## Prerequisites (documented in README)

- The host project must already be enabled as a Shared VPC host and the service project attached — an org-level operation (`compute.xpnAdmin`), **not** performed by this module.
- The credentials running terraform need IAM admin on **both** projects.

## Validation

- `terraform fmt -check` and `terraform validate` pass (the two checks this repo's CI runs).
- `terraform plan`/apply not run here (needs live GCP credentials); an end-to-end Shared VPC onboarding is tracked separately.

# References

- BYOC-551: https://linear.app/clickhouse/issue/BYOC-551
- GKE Shared VPC: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc