### PR TITLE
ci: guard modules/aws as a generated directory

### DIFF
--- a/.github/workflows/generated-guard.yaml
+++ b/.github/workflows/generated-guard.yaml
@@ -1,0 +1,34 @@
+name: Guard generated modules
+
+on:
+  pull_request:
+    paths:
+      - "modules/aws/**"
+
+jobs:
+  guard:
+    name: Reject manual edits to generated modules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail non-bot changes to modules/aws
+        if: |
+          !contains(fromJSON('["workflow-authentication-2[bot]", "workflow-authentication[bot]"]'), github.event.pull_request.user.login) &&
+          !contains(github.event.pull_request.labels.*.name, 'generated-override')
+        run: |
+          echo "::error::modules/aws is generated from ClickHouse/data-plane-infrastructure (aws/iac/environments/prod/byoc-prod/global/onboarding/tf-template-byoc-cdk). Edit the generator there and let CI re-sync. Apply the 'generated-override' label to bypass in an emergency."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify GENERATED headers intact
+        run: |
+          status=0
+          for f in modules/aws/*.tf; do
+            [ -e "$f" ] || continue
+            if ! head -5 "$f" | grep -q "GENERATED"; then
+              echo "::error file=$f::missing GENERATED header"
+              status=1
+            fi
+          done
+          exit $status

--- a/.github/workflows/generated-guard.yaml
+++ b/.github/workflows/generated-guard.yaml
@@ -2,6 +2,7 @@ name: Guard generated modules
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "modules/aws/**"
 
@@ -15,7 +16,7 @@ jobs:
           !contains(fromJSON('["workflow-authentication-2[bot]", "workflow-authentication[bot]"]'), github.event.pull_request.user.login) &&
           !contains(github.event.pull_request.labels.*.name, 'generated-override')
         run: |
-          echo "::error::modules/aws is generated from ClickHouse/data-plane-infrastructure (aws/iac/environments/prod/byoc-prod/global/onboarding/tf-template-byoc-cdk). Edit the generator there and let CI re-sync. Apply the 'generated-override' label to bypass in an emergency."
+          echo "::error::modules/aws is generated and published automatically by ClickHouse; manual edits will be overwritten by the next sync. If you believe a change is needed, open an issue. Maintainers: apply the 'generated-override' label to bypass in an emergency."
           exit 1
 
       - name: Checkout


### PR DESCRIPTION
### What
- Adds a guard workflow: PRs touching `modules/aws/**` fail unless authored by the sync bot or labeled `generated-override`.
- Verifies `.tf` files under `modules/aws/` keep their GENERATED header.

### Why
- `modules/aws/` is generated and synced automatically by ClickHouse internal CI; manual edits there would be overwritten by the next sync.

### Follow-up (repo admins)
- Consider marking the `guard` job as a required status check on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
