### PR TITLE
docs: link AWS onboarding module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains Terraform module to bootstrap a BYOC environment for Cl
 
 See terraform modules for supported cloud:
 
+- [AWS](./modules/aws/)
 - [GCP](./modules/gcp/)
 - [Azure](./modules/azure/)
 


### PR DESCRIPTION
Follow-up to #28 — the AWS module is now published under `modules/aws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)