### PR TITLE
ci: guard aws-per-infra-iam and auto-release bot sync merges

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -32,5 +32,11 @@ jobs:
           fi
           IFS=. read -r major minor patch <<< "${latest#v}"
           next="v${major}.${minor}.$((patch + 1))"
-          changed=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- modules/ | cut -d/ -f1-2 | sort -u | paste -sd ', ' -)
-          gh release create "$next" --target "${{ github.sha }}" --title "$next" --notes $'Automated release of synced generated modules.\n\nChanged: '"${changed}"$'\n\nThese modules are generated and published automatically by ClickHouse; see each module\'s README for usage. Always use the latest release.'
+          before="${{ github.event.before }}"
+          if [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            changed="(full sync)"
+          else
+            changed=$(git diff --name-only "$before" "${{ github.sha }}" -- modules/ | cut -d/ -f1-2 | sort -u | paste -sd ', ' -)
+          fi
+          notes=$'Automated release of synced generated modules.\n\nChanged: '"${changed}"$'\n\nThese modules are generated and published automatically by ClickHouse; see each module\'s README for usage. Always use the latest release.'
+          gh release create "$next" --target "${{ github.sha }}" --title "$next" --notes "$notes"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,0 +1,36 @@
+name: Auto-release synced modules
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "modules/aws/**"
+      - "modules/aws-per-infra-iam/**"
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Tag patch release for bot sync
+    if: "startsWith(github.event.head_commit.message, 'chore(aws): sync')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create next patch release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          if [ -z "$latest" ]; then
+            echo "::error::no existing v* tag found; cannot compute next patch version"
+            exit 1
+          fi
+          IFS=. read -r major minor patch <<< "${latest#v}"
+          next="v${major}.${minor}.$((patch + 1))"
+          changed=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- modules/ | cut -d/ -f1-2 | sort -u | paste -sd ', ' -)
+          gh release create "$next" --target "${{ github.sha }}" --title "$next" --notes $'Automated release of synced generated modules.\n\nChanged: '"${changed}"$'\n\nThese modules are generated and published automatically by ClickHouse; see each module\'s README for usage. Always use the latest release.'

--- a/.github/workflows/generated-guard.yaml
+++ b/.github/workflows/generated-guard.yaml
@@ -5,18 +5,19 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "modules/aws/**"
+      - "modules/aws-per-infra-iam/**"
 
 jobs:
   guard:
     name: Reject manual edits to generated modules
     runs-on: ubuntu-latest
     steps:
-      - name: Fail non-bot changes to modules/aws
+      - name: Fail non-bot changes to generated modules
         if: |
           !contains(fromJSON('["workflow-authentication-2[bot]", "workflow-authentication[bot]"]'), github.event.pull_request.user.login) &&
           !contains(github.event.pull_request.labels.*.name, 'generated-override')
         run: |
-          echo "::error::modules/aws is generated and published automatically by ClickHouse; manual edits will be overwritten by the next sync. If you believe a change is needed, open an issue. Maintainers: apply the 'generated-override' label to bypass in an emergency."
+          echo "::error::modules/aws and modules/aws-per-infra-iam are generated and published automatically by ClickHouse; manual edits will be overwritten by the next sync. If you believe a change is needed, open an issue. Maintainers: apply the 'generated-override' label to bypass in an emergency."
           exit 1
 
       - name: Checkout
@@ -25,7 +26,7 @@ jobs:
       - name: Verify GENERATED headers intact
         run: |
           status=0
-          for f in modules/aws/*.tf; do
+          for f in modules/aws/*.tf modules/aws-per-infra-iam/*.tf; do
             [ -e "$f" ] || continue
             if ! head -5 "$f" | grep -q "GENERATED"; then
               echo "::error file=$f::missing GENERATED header"


### PR DESCRIPTION
### What
- Extends the generated-modules guard to cover the upcoming `modules/aws-per-infra-iam`.
- Adds auto-release: pushes to main whose head commit starts with `chore(aws): sync` (bot sync squash merges only) create the next **patch** release automatically, with release notes listing the changed module dirs. Human-authored GCP/Azure changes keep today's manual tagging.

### Why
- The per-infra IAM module regenerates whenever ClickHouse's per-infra role definitions change — a much higher cadence than the management role. Auto-patch-tagging keeps "always use the latest release" true without manual release toil.

### Review point
- Release semantics: only bot sync merges auto-tag (patch bump). Manual minor/major tags remain available for anything human-driven. Shout if you'd rather gate this differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)