### PR TITLE
ci: serialize auto-release; use version placeholders in module docs

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -7,12 +7,18 @@ on:
       - "modules/aws/**"
       - "modules/aws-per-infra-iam/**"
 
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
 jobs:
   tag:
     name: Tag patch release for bot sync
+    # Relies on squash- or rebase-merging the sync PR (head commit message = PR title).
+    # A merge-commit merge would produce "Merge pull request #N..." and silently skip the release.
     if: "startsWith(github.event.head_commit.message, 'chore(aws): sync')"
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +42,8 @@ jobs:
           if [ "$before" = "0000000000000000000000000000000000000000" ]; then
             changed="(full sync)"
           else
-            changed=$(git diff --name-only "$before" "${{ github.sha }}" -- modules/ | cut -d/ -f1-2 | sort -u | paste -sd ', ' -)
+            changed=$(git diff --name-only "$before" "${{ github.sha }}" -- modules/ | cut -d/ -f1-2 | sort -u | paste -sd ',' -)
+            changed="${changed//,/, }"
           fi
           notes=$'Automated release of synced generated modules.\n\nChanged: '"${changed}"$'\n\nThese modules are generated and published automatically by ClickHouse; see each module\'s README for usage. Always use the latest release.'
           gh release create "$next" --target "${{ github.sha }}" --title "$next" --notes "$notes"

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -41,7 +41,7 @@ provider "azurerm" {
 }
 
 module "clickhouse_onboarding" {
-  source = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/azure?ref=v1.1.1"
+  source = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/azure?ref=<version>"
 }
 
 output "tenant_id" {
@@ -56,6 +56,10 @@ output "service_principal_client_id" {
   value = module.clickhouse_onboarding.service_principal_client_id
 }
 ```
+
+Replace `<version>` with the latest tag from the module's
+[releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases)
+— always use the latest release.
 
 ## Inputs
 

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -10,10 +10,14 @@ provider "google" {
 }
 
 module "clickhouse_onboarding" {
-  source     = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.2.0"
+  source     = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=<version>"
   project_id = "replace-with-your-clickhouse-byoc-project-id"
 }
 ```
+
+Replace `<version>` with the latest tag from the module's
+[releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases)
+— always use the latest release.
 
 ### Shared VPC (bring a VPC from a different project)
 
@@ -21,7 +25,7 @@ If the VPC you bring lives in a **different** GCP project (the Shared VPC *host*
 
 ```hcl
 module "clickhouse_onboarding" {
-  source                            = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=v1.2.0"
+  source                            = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=<version>"
   project_id                        = "replace-with-your-clickhouse-byoc-service-project-id"
   shared_vpc_host_project_id        = "replace-with-your-shared-vpc-host-project-id"
   shared_vpc_host_subnet_region     = "us-central1"
@@ -29,6 +33,10 @@ module "clickhouse_onboarding" {
   enable_shared_vpc_private_link    = true # only if you will use ClickHouse Private Service Connect (PrivateLink)
 }
 ```
+
+Replace `<version>` with the latest tag from the module's
+[releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases)
+— always use the latest release.
 
 By default the host project grants are read-only (observe the brought network/subnet); GKE consumes the host subnet via a `compute.networkUser` binding. Set `enable_shared_vpc_private_link = true` to additionally grant the host-project permissions needed to manage the PrivateLink PSC NAT subnet (subnets in a Shared VPC belong to the host project). Leave it `false` to keep the host-project permission surface minimal.
 


### PR DESCRIPTION
## Summary

- **Concurrency guard** (`auto-release.yaml`): adds `concurrency: group: auto-release, cancel-in-progress: false` at the workflow top level. Without it, two back-to-back sync merges race to compute `latest + 1` from the same base tag, causing a duplicate-tag push error and a lost release.
- **Merge-strategy comment** (`auto-release.yaml`): documents that the `startsWith(…'chore(aws): sync')` guard depends on squash- or rebase-merge; a standard merge commit silently skips the release.
- **Version placeholders** (`modules/gcp/README.md`, `modules/azure/README.md`): both READMEs hard-pinned old tags (`v1.2.0`, `v1.1.1` respectively). Since releases now auto-increment on every AWS sync, those pins drift faster than before. Replaced every `?ref=v<semver>` with `?ref=<version>` and added a one-liner directing readers to the releases page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)