### PR TITLE
feat(gcp): add include_vpc_write_permissions for bring-your-own-VPC

### DIFF
--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -19,6 +19,24 @@ Replace `<version>` with the latest tag from the module's
 [releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases)
 — always use the latest release.
 
+### Bring your own VPC (same project)
+
+If you pre-create and manage the VPC network, routes, and Cloud NAT yourself within the BYOC project, set `include_vpc_write_permissions = false`. ClickHouse then does **not** get permissions to create, delete, or modify the network topology (networks, routes, Cloud Routers, subnet attributes), but retains read and use access to it. ClickHouse still creates and manages the resources it owns inside your VPC — the PrivateLink (PSC) NAT subnet and service attachment, and ingress/static IP addresses — so PrivateLink and load balancers keep working.
+
+```hcl
+module "clickhouse_onboarding" {
+  source                        = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/gcp?ref=<version>"
+  project_id                    = "replace-with-your-clickhouse-byoc-project-id"
+  include_vpc_write_permissions = false
+}
+```
+
+Replace `<version>` with the latest tag from the module's
+[releases page](https://github.com/ClickHouse/terraform-byoc-onboarding/releases)
+— always use the latest release.
+
+If the VPC you bring instead lives in a **different** project, use the Shared VPC setup below.
+
 ### Shared VPC (bring a VPC from a different project)
 
 If the VPC you bring lives in a **different** GCP project (the Shared VPC *host* project) than the BYOC *service* project where ClickHouse runs GKE, set `shared_vpc_host_project_id` (plus the host subnet's `shared_vpc_host_subnet_region` and `shared_vpc_host_private_subnet_id`). The module then grants the network and GKE Shared VPC permissions in the host project, in addition to the standard service-project setup.
@@ -51,6 +69,7 @@ By default the host project grants are read-only (observe the brought network/su
 |------|-------------|------|---------|:--------:|
 | project_id | (Required) The GCP project ID where resources will be provisioned | string | n/a | yes |
 | environment | (Optional) Environment. Default is `production`. The other values are reserved for internal use | string | `production` | no |
+| include_vpc_write_permissions | (Optional) Whether to grant permissions to manage your VPC network topology (create/delete/modify of networks, routes, Cloud Routers, and subnet attributes). Set to `false` for bring-your-own-VPC onboarding. ClickHouse always retains read and use access to the VPC and manages the resources it owns inside it (PrivateLink/PSC NAT subnet and service attachment, ingress/static IP addresses) | bool | `true` | no |
 | shared_vpc_host_project_id | (Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `shared_vpc_host_subnet_region` and `shared_vpc_host_private_subnet_id` are required | string | `""` | no |
 | shared_vpc_host_subnet_region | (Optional) The region of the Shared VPC host subnet. Required only when `shared_vpc_host_project_id` is set | string | `""` | no |
 | shared_vpc_host_private_subnet_id | (Optional) The name of the existing Shared VPC host subnet used for GKE nodes. Required only when `shared_vpc_host_project_id` is set | string | `""` | no |
@@ -73,12 +92,14 @@ By default the host project grants are read-only (observe the brought network/su
 | google_service_account.clickhouse_management_sa | Service Account to manage ClickHouse resources in BYOC project |
 | google_project_service.cloud_resource_manager | Enables Cloud Resource Manager service API |
 | google_project_iam_custom_role.clickhouse_common_role | Role to allow ClickHouse Cloud common operations |
-| google_project_iam_custom_role.clickhouse_vpc_role | Role to allow ClickHouse Cloud to manage VPC resources in your project |
+| google_project_iam_custom_role.clickhouse_vpc_role | Role to allow ClickHouse Cloud to read and use VPC resources, and to create/manage the ClickHouse-owned subnets, addresses, and PrivateLink (PSC) it provisions within the VPC |
+| google_project_iam_custom_role.clickhouse_vpc_write_role | Role to allow ClickHouse Cloud to create/delete/modify the VPC network topology (networks, routes, Cloud Routers, subnet attributes); created only when `include_vpc_write_permissions` is true |
 | google_project_iam_custom_role.clickhouse_cluster_role | Role to allow ClickHouse Cloud to manage cluster resources in your project |
 | google_project_iam_custom_role.clickhouse_storage_role | Role to allow ClickHouse Cloud to manage Object Storage resources in your project |
 | google_project_iam_custom_role.clickhouse_iam_role | Role to allow ClickHouse Cloud to manage IAM resources in your project |
 | google_project_iam_member.clickhouse_sa_roles["common_role"] | Grants `clickhouseCommonRole` to ClickHouse Management Service Account |
 | google_project_iam_member.clickhouse_sa_roles["vpc_role"] | Grants `clickhouseVPCRole` to ClickHouse Management Service Account |
+| google_project_iam_member.clickhouse_sa_roles["vpc_write_role"] | Grants `clickhouseVPCWriteRole` to ClickHouse Management Service Account; present only when `include_vpc_write_permissions` is true |
 | google_project_iam_member.clickhouse_sa_roles["cluster_role"] | Grants `clickhouseClusterRole` to ClickHouse Management Service Account |
 | google_project_iam_member.clickhouse_sa_roles["storage_role"] | Grants `clickhouseStorageRole` to ClickHouse Management Service Account |
 | google_project_iam_member.clickhouse_sa_roles["iam_role"] | Grants `clickhouseIamRole` to ClickHouse Management Service Account |

--- a/modules/gcp/locals.tf
+++ b/modules/gcp/locals.tf
@@ -1,11 +1,16 @@
 locals {
-  clickhouse_custom_roles = {
-    common_role  = google_project_iam_custom_role.clickhouse_common_role.id
-    vpc_role     = google_project_iam_custom_role.clickhouse_vpc_role.id
-    cluster_role = google_project_iam_custom_role.clickhouse_cluster_role.id
-    storage_role = google_project_iam_custom_role.clickhouse_storage_role.id
-    iam_role     = google_project_iam_custom_role.clickhouse_iam_role.id
-  }
+  clickhouse_custom_roles = merge(
+    {
+      common_role  = google_project_iam_custom_role.clickhouse_common_role.id
+      vpc_role     = google_project_iam_custom_role.clickhouse_vpc_role.id
+      cluster_role = google_project_iam_custom_role.clickhouse_cluster_role.id
+      storage_role = google_project_iam_custom_role.clickhouse_storage_role.id
+      iam_role     = google_project_iam_custom_role.clickhouse_iam_role.id
+    },
+    var.include_vpc_write_permissions ? {
+      vpc_write_role = google_project_iam_custom_role.clickhouse_vpc_write_role[0].id
+    } : {},
+  )
   clickhouse_crossplane_sa_map = {
     "production" = [
       "serviceAccount:asia-southeast1-gke-crossplane@dataplane-production.iam.gserviceaccount.com",

--- a/modules/gcp/roles.tf
+++ b/modules/gcp/roles.tf
@@ -20,18 +20,27 @@ resource "google_project_iam_custom_role" "clickhouse_common_role" {
   ]
 }
 
+# Always granted. Covers what ClickHouse needs even in a bring-your-own-VPC
+# setup: read/observe and use the VPC and related resources, plus create and
+# manage the ClickHouse-owned resources it provisions inside the VPC (in the
+# service project) regardless of who owns the network — the PrivateLink (PSC)
+# NAT subnet and service attachment, and the ingress/static IP addresses. The
+# customer's own network topology (networks, routes, Cloud Routers, subnet
+# attributes) lives in clickhouseVPCWriteRole, gated by
+# var.include_vpc_write_permissions.
+#
+# subnetworks/addresses create+delete stay here (not in the write role) because
+# ClickHouse creates a PSC NAT subnet and ingress IPs in the service project
+# even when the customer brings their own VPC; GCP IAM cannot scope these verbs
+# to only the ClickHouse-owned instances, and gating them breaks PSC and ingress
+# load balancers under bring-your-own-VPC.
 resource "google_project_iam_custom_role" "clickhouse_vpc_role" {
   role_id     = "clickhouseVPCRole"
   title       = "ClickHouse VPC Role"
-  description = "Role to allow ClickHouse Cloud to manage VPC resources in your project"
+  description = "Role to allow ClickHouse Cloud to read and use VPC resources in your project, and to manage the ClickHouse-owned subnets, addresses, and PrivateLink (PSC) it provisions within the VPC"
   permissions = [
     # Network
     "compute.networks.access",
-    "compute.networks.addPeering",
-    "compute.networks.create",
-    "compute.networks.createTagBinding",
-    "compute.networks.delete",
-    "compute.networks.deleteTagBinding",
     "compute.networks.get",
     "compute.networks.getEffectiveFirewalls",
     "compute.networks.getRegionEffectiveFirewalls",
@@ -39,13 +48,6 @@ resource "google_project_iam_custom_role" "clickhouse_vpc_role" {
     "compute.networks.listEffectiveTags",
     "compute.networks.listPeeringRoutes",
     "compute.networks.listTagBindings",
-    "compute.networks.mirror",
-    "compute.networks.removePeering",
-    "compute.networks.setFirewallPolicy",
-    "compute.networks.switchToCustomMode",
-    "compute.networks.update",
-    "compute.networks.updatePeering",
-    "compute.networks.updatePolicy",
     "compute.networks.use",
     "compute.networks.useExternalIp",
 
@@ -58,41 +60,27 @@ resource "google_project_iam_custom_role" "clickhouse_vpc_role" {
     "compute.forwardingRules.use",
     "compute.regionOperations.get",
 
-    # Subnetwork
+    # Subnetwork — read/use, plus create/delete/update for the ClickHouse-owned
+    # PSC NAT subnet created in the service project (also under bring-your-own-VPC)
     "compute.subnetworks.create",
-    "compute.subnetworks.createTagBinding",
     "compute.subnetworks.delete",
-    "compute.subnetworks.deleteTagBinding",
-    "compute.subnetworks.expandIpCidrRange",
     "compute.subnetworks.get",
     "compute.subnetworks.getIamPolicy",
     "compute.subnetworks.list",
     "compute.subnetworks.listEffectiveTags",
     "compute.subnetworks.listTagBindings",
-    "compute.subnetworks.mirror",
-    "compute.subnetworks.setIamPolicy",
-    "compute.subnetworks.setPrivateIpGoogleAccess",
     "compute.subnetworks.update",
     "compute.subnetworks.use",
     "compute.subnetworks.useExternalIp",
     "compute.subnetworks.usePeerMigration",
 
     # Route
-    "compute.routes.create",
-    "compute.routes.createTagBinding",
-    "compute.routes.delete",
-    "compute.routes.deleteTagBinding",
     "compute.routes.get",
     "compute.routes.list",
     "compute.routes.listEffectiveTags",
     "compute.routes.listTagBindings",
 
     # Router (Cloud Router)
-    "compute.routers.create",
-    "compute.routers.createTagBinding",
-    "compute.routers.delete",
-    "compute.routers.deleteRoutePolicy",
-    "compute.routers.deleteTagBinding",
     "compute.routers.get",
     "compute.routers.getRoutePolicy",
     "compute.routers.list",
@@ -100,17 +88,15 @@ resource "google_project_iam_custom_role" "clickhouse_vpc_role" {
     "compute.routers.listEffectiveTags",
     "compute.routers.listRoutePolicies",
     "compute.routers.listTagBindings",
-    "compute.routers.update",
-    "compute.routers.updateRoutePolicy",
     "compute.routers.use",
 
-    # Address (Static IPs)
+    # Address (Static IPs) — read/use, plus create/delete for the
+    # ClickHouse-owned ingress/static IPs created in the service project (also
+    # under bring-your-own-VPC)
     "compute.addresses.create",
     "compute.addresses.createInternal",
-    "compute.addresses.createTagBinding",
     "compute.addresses.delete",
     "compute.addresses.deleteInternal",
-    "compute.addresses.deleteTagBinding",
     "compute.addresses.get",
     "compute.addresses.list",
     "compute.addresses.listEffectiveTags",
@@ -118,6 +104,66 @@ resource "google_project_iam_custom_role" "clickhouse_vpc_role" {
     "compute.addresses.setLabels",
     "compute.addresses.use",
     "compute.addresses.useInternal",
+  ]
+}
+
+# Create/delete/modify permissions for the customer's VPC network topology:
+# the networks themselves, routes, Cloud Routers (Cloud NAT), and subnet
+# attributes (IAM policy, CIDR expansion, private Google access, tag bindings).
+# Gated by var.include_vpc_write_permissions: set it to false for
+# bring-your-own-VPC onboarding, where the customer pre-creates and manages
+# these resources. The role is only created and bound when writes are enabled.
+#
+# Note: this deliberately does NOT gate subnetworks/addresses create+delete —
+# ClickHouse must still create its own PSC NAT subnet and ingress IPs in the
+# service project even under bring-your-own-VPC. Those live in clickhouseVPCRole.
+resource "google_project_iam_custom_role" "clickhouse_vpc_write_role" {
+  count = var.include_vpc_write_permissions ? 1 : 0
+
+  role_id     = "clickhouseVPCWriteRole"
+  title       = "ClickHouse VPC Write Role"
+  description = "Role to allow ClickHouse Cloud to create, delete, and modify the VPC network topology (networks, routes, Cloud Routers, and subnet attributes) in your project"
+  permissions = [
+    # Network
+    "compute.networks.addPeering",
+    "compute.networks.create",
+    "compute.networks.createTagBinding",
+    "compute.networks.delete",
+    "compute.networks.deleteTagBinding",
+    "compute.networks.mirror",
+    "compute.networks.removePeering",
+    "compute.networks.setFirewallPolicy",
+    "compute.networks.switchToCustomMode",
+    "compute.networks.update",
+    "compute.networks.updatePeering",
+    "compute.networks.updatePolicy",
+
+    # Subnetwork (attribute management; create/delete stay in clickhouseVPCRole)
+    "compute.subnetworks.createTagBinding",
+    "compute.subnetworks.deleteTagBinding",
+    "compute.subnetworks.expandIpCidrRange",
+    "compute.subnetworks.mirror",
+    "compute.subnetworks.setIamPolicy",
+    "compute.subnetworks.setPrivateIpGoogleAccess",
+
+    # Route
+    "compute.routes.create",
+    "compute.routes.createTagBinding",
+    "compute.routes.delete",
+    "compute.routes.deleteTagBinding",
+
+    # Router (Cloud Router)
+    "compute.routers.create",
+    "compute.routers.createTagBinding",
+    "compute.routers.delete",
+    "compute.routers.deleteRoutePolicy",
+    "compute.routers.deleteTagBinding",
+    "compute.routers.update",
+    "compute.routers.updateRoutePolicy",
+
+    # Address (tag bindings; create/delete stay in clickhouseVPCRole)
+    "compute.addresses.createTagBinding",
+    "compute.addresses.deleteTagBinding",
   ]
 }
 

--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -14,6 +14,12 @@ variable "environment" {
   }
 }
 
+variable "include_vpc_write_permissions" {
+  type        = bool
+  description = "(Optional) Whether to grant permissions to manage your VPC network topology (create/delete/modify of networks, routes, Cloud Routers, and subnet attributes). Set to `false` for bring-your-own-VPC onboarding, where you pre-create and manage the VPC, routes, and Cloud NAT yourself. Regardless of this setting, ClickHouse always retains read and use access to the VPC and manages the resources it owns inside it (the PrivateLink/PSC NAT subnet and service attachment, and ingress/static IP addresses in the service project)."
+  default     = true
+}
+
 variable "shared_vpc_host_project_id" {
   type        = string
   description = "(Optional) The GCP project ID of the Shared VPC host project, when the VPC you bring lives in a different project than `project_id`. Leave empty for the standard same-project setup. When set, `shared_vpc_host_subnet_region` and `shared_vpc_host_private_subnet_id` are required."


### PR DESCRIPTION
# Why

https://clickhouse-inc.slack.com/archives/C06B5ARC5QV/p1783672518453419

Customers bringing their own GCP VPC in the same project want to manage the VPC network topology themselves and not grant ClickHouse permission to create/delete/modify it. The AWS onboarding module already supports this via `include_vpc_write_permissions`; the GCP module had no equivalent (only the broader Shared VPC knobs, which address a different scenario — a VPC in a separate host project).

# What

Adds an optional `include_vpc_write_permissions` variable (default `true`) to `modules/gcp`, and splits the former monolithic `clickhouseVPCRole` into two custom roles:

- **`clickhouseVPCRole`** — always granted. Read/use of the VPC, plus management of the ClickHouse-owned resources created in the service project even under bring-your-own-VPC: the PrivateLink (PSC) NAT subnet (`subnetworks.create/delete/update`), the PSC service attachment, and ingress/static IP addresses.
- **`clickhouseVPCWriteRole`** — gated by `include_vpc_write_permissions`. Create/delete/modify of the customer's VPC network topology: networks, routes, Cloud Routers (Cloud NAT), and subnet attributes (`setIamPolicy`, `expandIpCidrRange`, `setPrivateIpGoogleAccess`, tag bindings). Created and bound only when the flag is `true`.

README gains a "Bring your own VPC (same project)" section plus input/resource-table entries.

Key design decision: a literal port of the AWS variable (which gates subnet creation) would break GCP PrivateLink and internal load balancers. GCP PSC structurally requires ClickHouse to create a dedicated PSC-purpose NAT subnet, and internal ingress requires a ClickHouse-created internal address — both in the service project, even when the customer owns the VPC. GCP IAM cannot scope those verbs to only ClickHouse-owned instances, so `subnetworks`/`addresses` create stay always-granted; the customer's node subnets are untouched because the reconciler observes (never creates) them. What `include_vpc_write_permissions=false` removes is management of the network topology itself (networks, routes, Cloud NAT, subnet attributes) — none of which the reconciler exercises under bring-your-own-VPC.

With the default (`true`), the effective permission set is identical to before this change (the union of the two roles equals the original `clickhouseVPCRole`), so existing onboarding is unaffected.

# References

- Paired data-plane-application PR (BYOC cloud-validator alignment): https://github.com/ClickHouse/data-plane-application/pull/37067
