### PR TITLE
fix(gcp): grant GKE firewall authority in Shared VPC host project

### DIFF
--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -40,6 +40,8 @@ Replace `<version>` with the latest tag from the module's
 
 By default the host project grants are read-only (observe the brought network/subnet); GKE consumes the host subnet via a `compute.networkUser` binding. Set `enable_shared_vpc_private_link = true` to additionally grant the host-project permissions needed to manage the PrivateLink PSC NAT subnet (subnets in a Shared VPC belong to the host project). Leave it `false` to keep the host-project permission surface minimal.
 
+Because a GKE cluster on a Shared VPC has its network in the host project, GKE also creates its firewall rules there — the master→node rule (kubelet/webhook ports) and the load-balancer health-check rules. The module therefore enables the Container API on the host project (so the host project's GKE service agent exists) and grants the service project's GKE service agent a scoped firewall role (`compute.firewalls.*` + `compute.networks.updatePolicy`) in the host project. Without this, admission webhooks and metrics-server degrade and internal load balancers (including the PrivateLink PSC ingress) never become healthy.
+
 **Prerequisites for Shared VPC:**
 
 - The host project must already be enabled as a [Shared VPC host](https://cloud.google.com/vpc/docs/provisioning-shared-vpc) and the service project (`project_id`) attached to it. This is an org-level operation (`compute.xpnAdmin`) and is **not** performed by this module.
@@ -65,6 +67,7 @@ By default the host project grants are read-only (observe the brought network/su
 | shared_vpc_enabled | Whether Shared VPC host-project resources were provisioned (true when `shared_vpc_host_project_id` is set) | bool |
 | shared_vpc_host_role | The ID of the ClickHouse Shared VPC host role granted in the host project, or null when Shared VPC is not used | string |
 | gke_service_agent_member | The service project's GKE service agent granted access to the Shared VPC host project, or null when Shared VPC is not used | string |
+| gke_shared_vpc_firewall_role | The ID of the firewall role granted to the GKE service agent in the host project, or null when Shared VPC is not used | string |
 
 ## Resources
 
@@ -88,6 +91,9 @@ By default the host project grants are read-only (observe the brought network/su
 | google_project_service.container | [Shared VPC] Enables the Container API on the service project so its GKE service agent exists |
 | google_project_iam_member.gke_host_service_agent_user | [Shared VPC] Grants `roles/container.hostServiceAgentUser` to the service project's GKE service agent on the host project |
 | google_compute_subnetwork_iam_member.network_user | [Shared VPC] Grants `roles/compute.networkUser` on the host subnet to the GKE service agent, Google APIs SA, and ClickHouse Management Service Account |
+| google_project_service.container_host | [Shared VPC] Enables the Container API on the host project so its GKE service agent exists (creates cluster-lifecycle firewall rules in the host network) |
+| google_project_iam_custom_role.clickhouse_gke_shared_vpc_firewall_role | [Shared VPC] Role allowing the GKE service agent to manage cluster/load-balancer firewall rules in the host project |
+| google_project_iam_member.gke_shared_vpc_firewall | [Shared VPC] Grants `clickhouseGKESharedVPCFirewallRole` to the service project's GKE service agent in the host project |
 
 ## Requirements
 

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -24,3 +24,8 @@ output "gke_service_agent_member" {
   value       = local.shared_vpc ? local.gke_service_agent_member : null
   description = "The service project's GKE service agent granted access to the Shared VPC host project, or null when Shared VPC is not used"
 }
+
+output "gke_shared_vpc_firewall_role" {
+  value       = one(google_project_iam_custom_role.clickhouse_gke_shared_vpc_firewall_role[*].id)
+  description = "The ID of the firewall role granted to the GKE service agent in the host project, or null when Shared VPC is not used"
+}

--- a/modules/gcp/shared_vpc.tf
+++ b/modules/gcp/shared_vpc.tf
@@ -50,6 +50,23 @@ locals {
     local.shared_vpc_host_base_permissions,
     local.enable_psc_host ? local.shared_vpc_host_psc_permissions : [],
   )
+
+  # Under Shared VPC, GKE creates its firewall rules in the host project (the
+  # cluster's network lives there), but the service project's GKE service agent
+  # has no authority to write them: hostServiceAgentUser + subnet networkUser do
+  # not include compute.firewalls. Without these the L4 ILB health-check rule
+  # (130.211.0.0/22, 35.191.0.0/16) is never created -> istio-ingress-private
+  # backends stay unhealthy -> PrivateLink PSC is dead; and the master->node
+  # rule (tcp 10250/443) breaks admission webhooks and metrics-server. This is
+  # GCP's documented granular alternative to roles/compute.securityAdmin.
+  gke_shared_vpc_firewall_permissions = [
+    "compute.firewalls.create",
+    "compute.firewalls.delete",
+    "compute.firewalls.get",
+    "compute.firewalls.list",
+    "compute.firewalls.update",
+    "compute.networks.updatePolicy",
+  ]
 }
 
 data "google_project" "service" {
@@ -126,4 +143,40 @@ resource "google_compute_subnetwork_iam_member" "network_user" {
   subnetwork = var.shared_vpc_host_private_subnet_id
   role       = "roles/compute.networkUser"
   member     = each.value
+}
+
+# Enable the Container API on the host project too. This provisions the host
+# project's own GKE service agent and auto-grants it roles/container.serviceAgent
+# there, which is what creates the cluster-lifecycle firewall rules in the host
+# network via the hostServiceAgentUser delegation above. disable_on_destroy is
+# false: other clusters/service-projects may share this host project.
+resource "google_project_service" "container_host" {
+  count = local.shared_vpc ? 1 : 0
+
+  project            = var.shared_vpc_host_project_id
+  service            = "container.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Scoped firewall authority for the service project's GKE service agent in the
+# host project. GKE's in-cluster controllers (e.g. the L4 ILB controller for
+# istio-ingress-private) run as this agent and create/update firewall rules in
+# the host network; hostServiceAgentUser does not cover compute.firewalls.
+resource "google_project_iam_custom_role" "clickhouse_gke_shared_vpc_firewall_role" {
+  count = local.shared_vpc ? 1 : 0
+
+  project     = var.shared_vpc_host_project_id
+  role_id     = "clickhouseGKESharedVPCFirewallRole"
+  title       = "ClickHouse GKE Shared VPC Firewall Role"
+  description = "Allows the service project's GKE service agent to manage its cluster/load-balancer firewall rules in the Shared VPC host project"
+  permissions = local.gke_shared_vpc_firewall_permissions
+}
+
+resource "google_project_iam_member" "gke_shared_vpc_firewall" {
+  count = local.shared_vpc ? 1 : 0
+
+  depends_on = [google_project_service.container]
+  project    = var.shared_vpc_host_project_id
+  role       = google_project_iam_custom_role.clickhouse_gke_shared_vpc_firewall_role[0].id
+  member     = local.gke_service_agent_member
 }


### PR DESCRIPTION
# Why

A GKE cluster on a Shared VPC has its network in the **host** project, so GKE creates its firewall rules there — the `gke-<cluster>-<hash>-master` rule (control plane → node, tcp/10250 kubelet + tcp/443 webhooks/metrics-server) and the L4 internal-LB health-check rules (source ranges `130.211.0.0/22`, `35.191.0.0/16`).

As merged (#26), no identity could write firewall rules in the host project: the service project's GKE service agent held only `roles/container.hostServiceAgentUser` + subnet-level `roles/compute.networkUser` (neither includes `compute.firewalls.*`), the `clickhouseSharedVPCHostRole` granted to the management SA had no firewall permissions, and the Container API was enabled only on the service project. Per GCP's Shared VPC contract, the *service project's* GKE service account is the identity that must create/manage those host-project firewall rules and needs explicit `compute.firewalls` permissions there.

Impact under Shared VPC (async, in the customer's account — not a clean provisioning error):
- The `istio-ingress-private` L4 ILB health-check firewall rule is never created → backends stay unhealthy → the PrivateLink PSC `ServiceAttachment` (which targets that ILB's forwarding rule) is dead.
- The master→node rule is never created → admission webhooks and metrics-server/HPA degrade.

Latent without Shared VPC (everything lives in one project, where the GKE service agent already has `container.serviceAgent`), which is why it isn't caught today — a PrivateLink-on **and** -off Shared VPC e2e would.

# What

Gated entirely on `shared_vpc` (unchanged for same-project callers):

- Enable `container.googleapis.com` on the **host** project (`google_project_service.container_host`), so the host project's GKE service agent exists and is auto-granted `roles/container.serviceAgent` there — this is what creates the cluster-lifecycle firewall rules in the host network via the `hostServiceAgentUser` delegation. `disable_on_destroy = false` (other clusters/service-projects may share the host project).
- Grant the **service project's** GKE service agent a scoped firewall custom role `clickhouseGKESharedVPCFirewallRole` in the host project — `compute.firewalls.{create,delete,get,list,update}` + `compute.networks.updatePolicy`. This is GCP's documented *granular* alternative to `roles/compute.securityAdmin`, covering the rules created by in-cluster controllers (e.g. the L4 ILB controller).

New output `gke_shared_vpc_firewall_role`; README updated (behavior note + resources table).

Note on standing access: this is a project-scope firewall grant to the Google-managed GKE robot in the customer's host project. GKE-generated firewall names are hash-based, so IAM-Condition name-scoping isn't practical; containment is the `shared_vpc` gate + the granular role (vs Security Admin).

## Validation

- `terraform fmt -check -recursive` and `terraform validate` pass (the two checks this repo's CI runs).
- `terraform plan`/apply not run (needs live GCP credentials on both projects); covered by the separately-tracked Shared VPC e2e.

# References

- BYOC-553 design review, finding #2: https://linear.app/clickhouse/project/gcp-shared-vpc-support-1699f5225a33/activity#comment-09bc8e4c
- Follows #26 (Shared VPC host project support)
- GKE Shared VPC firewall management: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc