### PR TITLE
fix(gcp): grant clickhouseStorageRole object-level perms for bucket teardown

### DIFF
--- a/modules/gcp/roles.tf
+++ b/modules/gcp/roles.tf
@@ -631,6 +631,14 @@ resource "google_project_iam_custom_role" "clickhouse_storage_role" {
     "storage.buckets.setIamPolicy",
     "storage.buckets.setIpFilter",
     "storage.buckets.update",
+    # Object-level access is required to tear down ClickHouse-managed buckets:
+    # bucket deletion runs with force_destroy=true, which must first list and
+    # delete the objects inside (e.g. the monitoring bucket's Thanos TSDB
+    # blocks) before removing the bucket. Without these, bucket delete 403s and
+    # the infra is stuck terminating (BYOC-768).
+    "storage.objects.list",
+    "storage.objects.get",
+    "storage.objects.delete",
   ]
 }
 


### PR DESCRIPTION
## Why

GCP BYOC infras get stuck `terminating` forever once any ClickHouse-managed bucket is non-empty. The management SA (`clickhouse-management@<project>`, which Crossplane impersonates for all GCS ops) holds `clickhouseStorageRole`, and that role has every `storage.buckets.*` permission but **no `storage.objects.*`**. Bucket deletion runs with `force_destroy=true`, which must first list + delete the objects inside before removing the bucket — so it 403s on `storage.objects.list` and the delete never completes.

This stayed latent because the affected buckets used to be empty (bucket delete then only needs `storage.buckets.delete`, which the role has). Once the per-infra monitoring bucket started receiving Thanos/Prometheus TSDB blocks it became non-empty, and every teardown wedged — 8+ dev testinfra cells stuck terminating (earliest 07-08), which also leaked dead-SA bindings onto the shared billing bucket until it hit the GCS policy-size cap and blocked new infra creation.

## What

Add `storage.objects.list`, `storage.objects.get`, `storage.objects.delete` to `clickhouseStorageRole`. These apply only to ClickHouse-managed buckets in the customer project, consistent with the role's purpose. Mgmt-side roles already carry these; this closes the gap on the customer-facing role only.

## Rollout note

Customer-facing role change — existing GCP BYOC customers pick it up on next `terraform apply`. Companion validator update in data-plane-application flags stale roles. Dev test project ch-byoc-test-3842 was patched manually to immediately unblock the stuck cells.

Linear: https://linear.app/clickhouse/issue/BYOC-768