### PR TITLE
ci(auto-release): auto release on change to any module

### DIFF
--- a/.github/scripts/plan-release.sh
+++ b/.github/scripts/plan-release.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Decides whether the current main commit warrants a release, and which version
+# to cut. Writes `version` to $GITHUB_OUTPUT (empty means nothing to release)
+# and the release body to release-notes.md.
+set -euo pipefail
+
+skip() {
+  echo "::notice::$1"
+  echo "version=" >>"$GITHUB_OUTPUT"
+  exit 0
+}
+
+last=$(git tag -l 'v*' --sort=-v:refname | head -1)
+if [ -z "$last" ]; then
+  echo "::error::no existing v* tag found; cannot compute the next version"
+  exit 1
+fi
+if [[ ! $last =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "::error::latest tag '$last' is not vMAJOR.MINOR.PATCH"
+  exit 1
+fi
+major=${BASH_REMATCH[1]}
+minor=${BASH_REMATCH[2]}
+patch=${BASH_REMATCH[3]}
+
+already=$(git tag --points-at HEAD -l 'v*' | paste -sd ' ' -)
+if [ -n "$already" ]; then
+  skip "$already already points at this commit; assuming it was released by hand"
+fi
+
+if ! git merge-base --is-ancestor "$last" HEAD; then
+  echo "::warning::$last is not an ancestor of HEAD; release notes may be inaccurate"
+fi
+
+# Compare against the last release rather than github.event.before: GitHub keeps
+# only one pending run per concurrency group, so a push whose run was dropped
+# from the queue must still end up in the next release.
+changed=$(git diff --name-only "$last" HEAD -- modules/)
+[ -n "$changed" ] || skip "no module changes since $last"
+
+# Labels of the PRs merged since the last release. Walking first parents keeps
+# this to one API call per merge/squash commit instead of one per commit.
+labels=""
+for sha in $(git rev-list --first-parent "$last..HEAD"); do
+  labels+=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls" --jq '.[].labels[].name' 2>/dev/null || true)
+  labels+=$'\n'
+done
+
+has_label() { grep -qxF "$1" <<<"$labels"; }
+
+if has_label "release:skip"; then
+  skip "release:skip label on a PR in this range"
+fi
+
+if has_label "release:major"; then
+  bump=major
+elif has_label "release:minor"; then
+  bump=minor
+elif has_label "release:patch"; then
+  bump=patch
+else
+  # Conventional commits, read over the whole range so the bump is independent
+  # of whether PRs were squashed, rebased or merged.
+  subjects=$(git log --format='%s' "$last..HEAD")
+  if grep -qE '^[a-z]+(\([^)]*\))?!:' <<<"$subjects" ||
+    git log --format='%b' "$last..HEAD" | grep -qE '^BREAKING[ -]CHANGE'; then
+    bump=major
+  elif grep -qE '^feat(\([^)]*\))?:' <<<"$subjects"; then
+    bump=minor
+  else
+    bump=patch
+  fi
+
+  if ! grep -qvE '(^|/)README\.md$' <<<"$changed"; then
+    skip "only module docs changed since $last; label a PR release:patch to force a release"
+  fi
+fi
+
+case $bump in
+major) next="v$((major + 1)).0.0" ;;
+minor) next="v${major}.$((minor + 1)).0" ;;
+patch) next="v${major}.${minor}.$((patch + 1))" ;;
+esac
+
+modules=$(cut -d/ -f1-2 <<<"$changed" | sort -u | paste -sd ',' - | sed 's/,/, /g')
+changes=$(git log --full-history --no-merges --format='- %s' "$last..HEAD" -- modules/)
+[ -n "$changes" ] || changes=$(git log --no-merges --format='- %s' "$last..HEAD")
+
+cat >release-notes.md <<EOF
+Automated release. Changed modules: ${modules}
+
+## Changes since ${last}
+
+${changes}
+
+Pin a module with \`?ref=${next}\`; see each module's README for usage.
+EOF
+
+echo "version=$next" >>"$GITHUB_OUTPUT"
+echo "::notice::releasing $next ($bump bump from $last)"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,11 +1,10 @@
-name: Auto-release synced modules
+name: Auto-release module changes
 
 on:
   push:
     branches: [main]
     paths:
-      - "modules/aws/**"
-      - "modules/aws-per-infra-iam/**"
+      - "modules/**"
 
 concurrency:
   group: auto-release
@@ -13,13 +12,27 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
-  tag:
-    name: Tag patch release for bot sync
-    # Relies on squash- or rebase-merging the sync PR (head commit message = PR title).
-    # A merge-commit merge would produce "Merge pull request #N..." and silently skip the release.
-    if: "startsWith(github.event.head_commit.message, 'chore(aws): sync')"
+  validate:
+    name: Validate terraform configuration
+    # Required checks are not strict, so a PR merged on a stale base can break
+    # main; re-check before publishing a release from it.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Terraform validate
+        uses: dflook/terraform-validate@v2
+
+      - name: Terraform fmt check
+        uses: dflook/terraform-fmt-check@v2
+
+  release:
+    name: Tag release
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,23 +40,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create next patch release
+      - name: Plan release
+        id: plan
         env:
           GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/plan-release.sh
+
+      - name: Create release
+        if: steps.plan.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.plan.outputs.version }}
         run: |
-          latest=$(git tag -l 'v*' --sort=-v:refname | head -1)
-          if [ -z "$latest" ]; then
-            echo "::error::no existing v* tag found; cannot compute next patch version"
-            exit 1
-          fi
-          IFS=. read -r major minor patch <<< "${latest#v}"
-          next="v${major}.${minor}.$((patch + 1))"
-          before="${{ github.event.before }}"
-          if [ "$before" = "0000000000000000000000000000000000000000" ]; then
-            changed="(full sync)"
-          else
-            changed=$(git diff --name-only "$before" "${{ github.sha }}" -- modules/ | cut -d/ -f1-2 | sort -u | paste -sd ',' -)
-            changed="${changed//,/, }"
-          fi
-          notes=$'Automated release of synced generated modules.\n\nChanged: '"${changed}"$'\n\nThese modules are generated and published automatically by ClickHouse; see each module\'s README for usage. Always use the latest release.'
-          gh release create "$next" --target "${{ github.sha }}" --title "$next" --notes "$notes"
+          gh release create "$VERSION" \
+            --target "${{ github.sha }}" \
+            --title "$VERSION" \
+            --notes-file release-notes.md

--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ See terraform modules for supported cloud:
 - [GCP](./modules/gcp/)
 - [Azure](./modules/azure/)
 
+## Releases
+
+Every push to `main` that changes `modules/**` is released automatically as a
+single repository-wide `vMAJOR.MINOR.PATCH` tag covering all modules. The bump is
+derived from the conventional-commit subjects merged since the last release:
+`feat!` or a `BREAKING CHANGE` footer gives a major, `feat` a minor, anything
+else a patch. Changes limited to module `README.md` files do not trigger a
+release.
+
+Label a PR to override that decision:
+
+| Label | Effect |
+| --- | --- |
+| `release:major` / `release:minor` / `release:patch` | Force that bump instead of the one inferred from commits |
+| `release:patch` | Also releases a docs-only change |
+| `release:skip` | Do not release this change; it ships with the next release |
+
+Tagging a commit by hand still works — the automation skips any commit that
+already has a `v*` tag, so cut a release manually when it needs curated notes.
+


### PR DESCRIPTION
## Why
Only the bot-synced AWS modules were released automatically

## What
Extend auto-release to all of `modules/**`, with the bump derived from conventional-commit subjects since the last tag (`feat!` → major, `feat` → minor, else patch).
Can override the bump with `release:major|minor|patch|skip` labels on the PR. (Labels will be created if this PR gets merged)