### PR TITLE
chore(byoc): add GCP permission serviceusage.services.get to common role

### DIFF
--- a/modules/gcp/roles.tf
+++ b/modules/gcp/roles.tf
@@ -17,6 +17,9 @@ resource "google_project_iam_custom_role" "clickhouse_common_role" {
 
     # Project operations
     "resourcemanager.projects.get",
+
+    # Service usage for validation checks
+    "serviceusage.services.get",
   ]
 }
 


### PR DESCRIPTION
Part of BYOC setup and validation in GCP we need the following GCP APIs enabled:
- Network Connectivity API, `networkconnectivity.googleapis.com`
- Identity and Access Management (IAM) API, `iam.googleapis.com`
- Kubernetes Engine API, `container.googleapis.com`

We could add the checks for whether those are enabled or not as part of validation API and creation...
But that would involve adding additional permission in terraform onboarding `serviceusage.services.get`.
This adds the permission to the common role.