### PR TITLE
chore(byoc): enable Network Connectivity API, IAM API, and Kubernetes…

### DIFF
--- a/modules/gcp/main.tf
+++ b/modules/gcp/main.tf
@@ -17,6 +17,24 @@ resource "google_project_service" "compute_engine" {
   disable_on_destroy = false
 }
 
+# Enable Network Connectivity API
+resource "google_project_service" "compute_engine" {
+  service            = "networkconnectivity.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Identity and Access Management (IAM) API
+resource "google_project_service" "compute_engine" {
+  service            = "iam.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Kubernetes Engine API
+resource "google_project_service" "compute_engine" {
+  service            = "container.googleapis.com"
+  disable_on_destroy = false
+}
+
 # Grant IAM roles to ClickHouse Management SA
 resource "google_project_iam_member" "clickhouse_sa_roles" {
   for_each = local.clickhouse_custom_roles


### PR DESCRIPTION
Part of BYOC setup and validation in GCP we need the following GCP APIs enabled:
- Network Connectivity API, `networkconnectivity.googleapis.com`
- Identity and Access Management (IAM) API, `iam.googleapis.com`
- Kubernetes Engine API, `container.googleapis.com`

This PR enabled these APIs.

https://github.com/ClickHouse/terraform-byoc-onboarding/pull/40